### PR TITLE
Add new Facebook page plugin

### DIFF
--- a/angular-easyfb.js
+++ b/angular-easyfb.js
@@ -506,6 +506,9 @@
     'fbFacepile': [
       'action', 'appId', 'colorscheme', 'href', 'maxRows',
       'size', 'width'
+    ],
+    'fbPage': [
+      'href', 'ref', 'share', 'showFaces', 'width', 'height', 'hide_cover', 'show_facepile', 'show_posts'
     ]
   };
 


### PR DESCRIPTION
This adds support for the new page plugin: https://developers.facebook.com/docs/plugins/page-plugin/

The like-box is now deprecated by Facebook (in favor of the new page plugin).