### PR TITLE
Update package.json.main to point to build/angulareasyfb.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "angular-easyfb",
   "version": "1.4.1",
   "description": "Super easy AngularJS + Facebook JavaScript SDK.",
-  "main": "index.js",
+  "main": "build/angular-easyfb.js",
   "directories": {},
   "scripts": {
     "test": "grunt test"


### PR DESCRIPTION
so it can be used with tools that allow importing scripts from node_modules
e.g. webpack:
require('script!angular-easyfb');