### PR TITLE
Targeting main file for importing with npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "angular-easyfb",
   "version": "1.4.1",
   "description": "Super easy AngularJS + Facebook JavaScript SDK.",
-  "main": "index.js",
+  "main": "src/angular-easyfb.js",
   "directories": {},
   "scripts": {
     "test": "grunt test"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "angular-easyfb",
   "version": "1.4.1",
   "description": "Super easy AngularJS + Facebook JavaScript SDK.",
-  "main": "src/angular-easyfb.js",
+  "main": "build/angular-easyfb.js",
   "directories": {},
   "scripts": {
     "test": "grunt test"


### PR DESCRIPTION
When using npm and ES6 loaders such jspm (System.js).
We have to import `angular-easyfb/src/angular-easyfb` instead of just `angular-easyfb`, because of package.json main file being index.js which doesn't exist.
Pointing to main file in build directory fixes this.

We could also point to build file if needed.