### PR TITLE
Add 'https' to facebook js sdk

### DIFF
--- a/build/angular-easyfb.js
+++ b/build/angular-easyfb.js
@@ -75,7 +75,7 @@ https://github.com/pc035860/angular-easyfb.git */
                     js = d.createElement("script");
                     js.id = id;
                     js.async = true;
-                    js.src = "//connect.facebook.net/" + ezfbLocale + "/sdk.js";
+                    js.src = "https://connect.facebook.net/" + ezfbLocale + "/sdk.js";
                     ref.parentNode.insertBefore(js, ref);
                 };
                 $timeout(insertScript, 0, false);


### PR DESCRIPTION
the js SDK link without `https` raise an error for me.